### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The latest stable release of Debian (which is "Jessie" at the time of writing th
 
 ### This installer is for *for Debian "Wheezy"* and *not: testing, sid, or debian variants*
 
-###FAQ:
+### FAQ:
 **Question: What's the difference between this installer and Valve's?**
 
 * Answer: This version comes with an extra folder called `i386-linux-gnu` and `x86_64-linux-gnu` which is from *Ubuntu's libc6 deb package*, it is saved in `/usr/lib/steam/`. The *steam-debian excutable loads said folder* which solves the need for glibc 2.15


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
